### PR TITLE
Fix preprocessing instruction

### DIFF
--- a/translation/README.md
+++ b/translation/README.md
@@ -24,8 +24,8 @@ python3 -m pip install --user --no-deps --editable .
 Next process the data into Fairseq format
 
 ```
-python3 structured-uncertainty/fairseq-preprocess.py  --source-lang en --target-lang ru \\
---trainpref wmt20_en_ru/train --validpref wmt20_en_ru/valid --testpref wmt20_en_ru/test19,wmt20_en_ru/reddit_dev  \\
+python3 structured-uncertainty/preprocess.py  --source-lang en --target-lang ru \\
+--trainpref wmt20_en_ru/train --validpref wmt20_en_ru/valid --testpref wmt20_en_ru/reddit_dev  \\
 --destdir data-bin/wmt20_en_ru --thresholdtgt 0 --thresholdsrc 0  --workers 24
 ```
 


### PR DESCRIPTION
Simple tweaks to make preprocessing work:

1.  Use [`preprocess`](https://github.com/KaosEngineer/structured-uncertainty/blob/master/preprocess.py) in the TLD of [`structured-uncertainty`](https://github.com/KaosEngineer/structured-uncertainty).  The current file does not seem to exist in the master branch.
2. Remove `wmt20_en_ru/test19` from the parameter.  Both `test_19.{en, ru}` are empty and this causes a `ZeroDivisionError` in this [code path](https://github.com/KaosEngineer/structured-uncertainty/blob/master/preprocess.py#L155).