### PR TITLE
Fix Translation Prepare Data Script

### DIFF
--- a/translation/data/prepare_data.sh
+++ b/translation/data/prepare_data.sh
@@ -159,7 +159,6 @@ for l in $src $tgt; do
     perl $TOKENIZER -threads 24 -a -l ${l} >>$tmp/reddit_dev.$l
 done
 
-exit
 
 echo "splitting train and valid..."
 for l in $src $tgt; do


### PR DESCRIPTION
Removed the `exit` command in `translation/data/prepare_data.sh` before splitting `train` and `valid`.  Otherwise, there was only a `tmp` folder under `wmt20_en_ru` and no `train.en`, for example, which is needed for further steps in the `README.md`. 